### PR TITLE
Change model output name from logits to audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ padded = torch.nn.functional.pad(audio, (0, padding))
 
 clean = []
 for i in tqdm(range(0, padded.shape[-1], chunk_size)):
-    audio_chunk = padded[:, i:i+chunk_size]
+    audio_chunk = padded[:, i:i + chunk_size]
     with torch.no_grad():
-        clean_chunk = model(audio_chunk[None]).logits
+        clean_chunk = model(audio_chunk[None]).audio
     clean.append(clean_chunk.squeeze(0))
 
 denoised = torch.concat(clean, 1)[:, :audio.shape[-1]]

--- a/tests/modeling/test_unet1d_model.py
+++ b/tests/modeling/test_unet1d_model.py
@@ -43,7 +43,7 @@ def test_model() -> None:
 
     audio = torch.randn(1, 1, config.max_length)
     with torch.no_grad():
-        recon = model(audio).logits
+        recon = model(audio).audio
 
     assert isinstance(recon, torch.Tensor)
     assert audio.shape == recon.shape
@@ -65,7 +65,7 @@ def test_lightning_module() -> None:
 
     # test forward
     with torch.no_grad():
-        recon = model(audio).logits
+        recon = model(audio).audio
 
     assert isinstance(recon, torch.Tensor)
     assert audio.shape == recon.shape

--- a/tests/modeling/test_waveunet_model.py
+++ b/tests/modeling/test_waveunet_model.py
@@ -45,7 +45,7 @@ def test_model() -> None:
 
     audio = torch.randn(1, 1, config.max_length)
     with torch.no_grad():
-        recon = model(audio).logits
+        recon = model(audio).audio
 
     assert isinstance(recon, torch.Tensor)
     assert audio.shape == recon.shape
@@ -67,7 +67,7 @@ def test_lightning_module() -> None:
 
     # test forward
     with torch.no_grad():
-        recon = model(audio).logits
+        recon = model(audio).audio
 
     assert isinstance(recon, torch.Tensor)
     assert audio.shape == recon.shape


### PR DESCRIPTION
This change makes sense because the audio, not the logits, is returned in the model output classes.