### PR TITLE
update README to reflect mono audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ audio, sr = torchaudio.load("noisy_audio.wav")
 if sr != model.config.sample_rate:
     audio = torchaudio.functional.resample(audio, sr, model.config.sample_rate)
 
+if audio.size(0) > 1:
+    audio = audio.mean(0, keepdim=True)
+
 chunk_size = model.config.max_length
 
 padding = abs(audio.size(-1) % chunk_size - chunk_size)


### PR DESCRIPTION
The current models only support mono audio. I updated the README example to ensure multi-channel audio is converted to mono. The gradio [demo](https://huggingface.co/spaces/wrice/denoisers) has also been updated. This should fix #21 
