### PR TITLE
Add support for sane sizes 16000, 32000, etc.

### DIFF
--- a/denoisers/modeling/unet1d/model.py
+++ b/denoisers/modeling/unet1d/model.py
@@ -245,7 +245,7 @@ class UNet1D(nn.Module):
         out = self.middle(out)
 
         for skip, layer in zip(reversed(skips), self.decoder_layers):
-            out = layer(out + skip)
+            out = layer(out[..., : skip.size(-1)] + skip)
 
         out = torch.concat([out, inputs], dim=1)
         out = self.out_conv(out)

--- a/denoisers/modeling/waveunet/model.py
+++ b/denoisers/modeling/waveunet/model.py
@@ -247,7 +247,7 @@ class WaveUNet(nn.Module):
         out = self.middle(out)
 
         for skip, layer in zip(reversed(skips), self.decoder_layers):
-            out = torch.concat([out, skip], dim=1)
+            out = torch.concat([out[..., : skip.size(-1)], skip], dim=1)
             out = layer(out)
 
         out = torch.concat([out, inputs], dim=1)


### PR DESCRIPTION
Previously the waveform models only supported multiples of 16384. I added cropping in the skip connections that will allow even multiples of seconds. For example: 16khz sample rate for 4 seconds would be 16000 * 4 instead of 16384 * 4.